### PR TITLE
I created a POSIX shell script alternative to randomize.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,15 @@ To see all available options type <code>typist --help</code> or just
 ### Tips
 
 Doing the same test over and over again isn't good practice. I have provided
-a text file and a small python script to randomize the most used words in the
-English language. You can use this script on any text file, though it will
-remove punctuation marks and reformats the text.
+a text file and a small python script and a shell script to randomize the most
+used words in the English language. You can use this script on any text file,
+though it will remove punctuation marks and reformats the text.
 
 ```
-python3 utils/randomize.py most-used-words.txt
+python3 utils/randomize.py most_used_words.txt
+# or
+utils/randomize.sh most_used_words.txt
 ```
-
 ---
 
 ### [Issues / Bugs](https://github.com/ny64/typist/issues)

--- a/utils/randomize.sh
+++ b/utils/randomize.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+# use a POSIX shell shuf alternative if none on the system
+command -v shuf > /dev/null 2> /dev/null || shuf() {
+    awk '
+        BEGIN {
+            srand();
+            OFMT = "%.17f"
+        }
+        {
+            print rand(), $0
+        }
+    ' "$@" | 
+    sort -k1,1n | 
+    cut -d ' ' -f2- ;}
+
+# first argument is the filename
+filename="$1"
+[ ! -f "$filename" ] && printf "%s\n" "You must provide a text file as argument." >&2 && exit 1
+
+words=""
+# read file line by line
+while IFS= read -r line; do
+    # split the line into words and set them as positional parameters
+    # shellcheck disable=SC2086
+    set -- $line
+    for val; do
+        # clean up each word: remove leading and trailing punctuation and quotes
+        val=$(printf "%s" "$val" | sed -e 's/^[({'"'"'"]*//' -e 's/[.,!?;:)]}'"'"'"]*$//')
+        words="$words
+$val"   # one word per line in $words var
+    done
+done < "$filename"
+
+line_length=0
+{
+    # loop over each shuffled words
+    printf "%s\n" "$words" | shuf | while IFS= read -r word; do
+        # update line length
+        line_length=$((line_length + ${#word} + 1))
+        # if line length exceeds 80 characters, make a new line
+        if [ "$line_length" -gt 80 ]; then
+            echo
+            # update line length
+            line_length=$(( ${#word} + 1 ))
+        fi
+        printf "%s " "$word"
+    done
+echo
+} > "$filename"


### PR DESCRIPTION
I created a POSIX shell script alternative to randomize.py that should work on all Linux, BSD and macOS systems out of the box, no Python required.
I think this fits well with the "only use the standard c libraries" goal of the project by providing a portable alternative to the Python script.

---
Usage example:
```
$ head most_used_words.txt
determine said had idea for do might touch safe village step travel phrase hunt
song free wish mountain problem has buy son once score dollar protect tree two
during force out piece dry told leg thank arm ready body south picture stretch
heart me school equate similar such join time seem your flat copy guess get
last bell wash kind door distant slow subject branch exact clean search name
off atom dream imagine hear fit group heavy wave a develop syllable natural
wood plural tube raise got thick must him break her can liquid answer possible
am basic bar make weather before corn stood read letter garden at much shore
large drink gas move rose window pretty test skin sugar fall star saw press
pull insect either miss tell type print nor consider wing heard follow toward

$ ./randomize.sh most_used_words.txt

$ head most_used_words.txt
sleep here triangle able warm than see slow if substance road fresh ride let
job language carry run make material question too suit only planet what iron
climb truck equate name fly found track represent force hot same mother pretty
pay art listen hold read claim had year long difficult necessary could area one
consonant fight small original dollar water melody again set land ice first
matter study can raise operate touch she supply why spring floor win heat count
collect cry best save leg start surprise desert as protect broad clock prove
teeth such suggest cat dad early fraction usual number tell term done you heavy
an consider trouble joy car chart magnet check pull give box glad bring those
crop mile card toward bat person decimal do example hole particular bank nature
```
---
Oh, and another thing. I can't help with this until I learn C, but on POSIX systems we have pipes, so I would like if typist could read the words from stdin so you could do something like this:
`$ randomize.sh most_used_words.txt | typist -`
(I would modify randomize.sh to output out of stdout by default.)

This is better because we don't have to write to the disk.
Another benefit: randomize.sh wouldn't overwrite the file, so you could pass it paths of text files without having to make a copy first.

It also gives us more extensibility and power.
For example, if you want a shorter test:
`$ randomize.sh most_used_words.txt | head -1 | typist -`
It keeps only the first line of the randomized text.

Or you could type a fortune cookie/quote:
`$ fortune | typist -`

Or a manual page:
`$ man 1p sed | typist -`